### PR TITLE
fix: remove obsolete variable

### DIFF
--- a/components.tfstack.hcl
+++ b/components.tfstack.hcl
@@ -4,10 +4,6 @@
 component "s3" {
   source = "./s3"
 
-  inputs = {
-    region = var.region
-  }
-
   providers = {
     aws    = provider.aws.this
     random = provider.random.this
@@ -18,7 +14,6 @@ component "lambda" {
   source = "./lambda"
 
   inputs = {
-    region    = var.region
     bucket_id = component.s3.bucket_id
   }
 
@@ -34,7 +29,6 @@ component "api_gateway" {
   source = "./api-gateway"
 
   inputs = {
-    region               = var.region
     lambda_function_name = component.lambda.function_name
     lambda_invoke_arn    = component.lambda.invoke_arn
   }


### PR DESCRIPTION
`region` is no variable in any of the component sources anymore. The region is now implicitly set via the `aws` provider passed to the components.
